### PR TITLE
Convert unitless module declaration into block form

### DIFF
--- a/lib/Pastebin/Shadowcat.pm6
+++ b/lib/Pastebin/Shadowcat.pm6
@@ -1,5 +1,4 @@
-module Pastebin::Shadowcat;
-{
+module Pastebin::Shadowcat {
     use LWP::Simple;
     use URI::Encode;
     use HTML::Entity;


### PR DESCRIPTION
Otherwise, it would have required a `unit` declarator and the braces would
have to have been removed.

The reason for this change is, that as of Rakudo 2015.05, the `unit`
declarator is required before using `module`, `class` or `grammar`
declarations (unless it uses a block).  Code still using the old blockless
semicolon form will throw a warning. This commit stops the warning from
appearing in the new Rakudo.
