### PR TITLE
HTML::Entity::Fast migration

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,7 +8,7 @@
   "depends": [
     "HTTP::UserAgent",
     "URI::Encode",
-    "HTML::Entity"
+    "HTML::Entity::Fast"
   ],
   "description": "Raku interface to http://fpaste.scsys.co.uk/",
   "license": "Artistic-2.0",

--- a/lib/Pastebin/Shadowcat.rakumod
+++ b/lib/Pastebin/Shadowcat.rakumod
@@ -1,6 +1,6 @@
 use HTTP::UserAgent;
 use URI::Encode;
-use HTML::Entity;
+use HTML::Entity::Fast;
 
 unit class Pastebin::Shadowcat:ver<2.002>:auth<zef:raku-community-modules>;
 
@@ -27,7 +27,7 @@ method fetch ($what) returns List {
         '<br>' \s+ '<b>' $<summary>=.+ '</b>' .+ '<pre>' $<paste>=.+ '</pre>'
     / or fail 'Could not find paste content on the returned page';
 
-    decode-entities(~$<paste>), decode-entities(~$<summary>),
+    decode-html-entities(~$<paste>), decode-html-entities(~$<summary>),
 }
 
 =begin pod


### PR DESCRIPTION
HTML::Entity is a very old, unmaintained module that isn't even compatible with zef anymore. HTML::Entity::Fast is a more elaborate, performant (as far as well-written NQP can go) module in proper conditions. It seems sensible to unbreak this module by depending on something that is up-to-date and that I can trust.